### PR TITLE
Define custom rules message and injecting field name to message

### DIFF
--- a/config/policies/validate.js
+++ b/config/policies/validate.js
@@ -31,6 +31,30 @@ const removeRule = (rules, rule) => {
   rules.indexOf(rule) !== -1 && rules.splice(rules.indexOf(rule), 1)
 }
 
+const resolveErrorMessages = (errors, settings) => {
+  const routeCustomMessages = _.get(settings, `customMessages`, {})
+  const globalCustomMessages = _.get(strapi, `config.validators.customMessages`, {})
+  const customMessages = _.merge(globalCustomMessages, routeCustomMessages)
+
+  return errors.map((error) => {
+    let customMessage
+    const hasRuleFieldMessage = _.has(settings, `rules.${error.field}.${error.validation}`)
+
+    // if message not defined in rules object: get from customMessages
+    if (!hasRuleFieldMessage) {
+      customMessage = _.get(
+        customMessages,
+        `${error.field}.${error.validation}`,
+        customMessages[error.validation]
+      )
+    }
+
+    const compiledMessage = _.template(customMessage ?? error.message);
+    error.message = compiledMessage({ 'field': error.field })
+    return error
+  })
+}
+
 const resolveSettings = (settings, ignoreRequired) => {
   const { fields, messages } = settings.rules ? resolveRules(settings.rules, ignoreRequired) : { fields: {}, messages: {} }
   return {
@@ -124,7 +148,7 @@ const resolveModule = async (ctx, module) => {
       strapi.log.error(error.message)
       ctx.badImplementation(error.message)
     } else {
-      ctx.badRequest(settings.message || "Invalid input data", error)
+      ctx.badRequest(settings.message || "Invalid input data", resolveErrorMessages(error, settings))
     }
     return ctx
   }

--- a/config/policies/validate.js
+++ b/config/policies/validate.js
@@ -106,7 +106,7 @@ const resolveModule = async (ctx, module) => {
   const { rules, messages } = resolveSettings(settings, ignoreRequired)
   // remove rules that doesn't have any validation
   for (const rule in rules) {
-    if (rules[rule].legnth == 0) delete rules[rule]
+    if (rules[rule].length == 0) delete rules[rule]
   }
   // Try to validate inputs applying rules
   try {


### PR DESCRIPTION
This PR adds ability to define custom validation messages for rules either globally by creating ~/config/validators.json, or per api content type in  ~/api/*/config/validators.json. In addition, it allows for injecting field name to messages by using lodash templates and field variable inside the custom message ```<%= field %>```. 

Object with key "customMessages" can be added to validators.json ```{ [rule] : "message" }``` below is an example:

in ```~/config/validators.json```
```
{
  "customMessages" : {
    "isActive.required" : "<%= field %> is required",
    "required" : "<%= field %> is required",
    "number" : "<%= field %> must be a valid number"
  }
}
```
or in ```~/api/*/config/validators.json```
```
{
  "validators": {
    "invoice-create": {
      "customMessages": {
        "isActive.required": "route isActive required message",
        "isActive.number": "route isActive number message",
        "number": "route <%= field %> must be a valid number"
      },
      "message": "It appears that there is some invalid information on your invoice.",
      "rules": {
        "referenceNumber": {
          "required": "This rule field required message",
          "number": "This rule field number message"
        },
        "amount": ["required","number"],
        "isActive": ["required", "number"],
        "description": ["string"]
      }
    }
  }
}
```

The priority is to messages defined inside rules object (in the example, it's referenceNumber), then key customMessages (in  the example, it's invoice-create), then to global customMessages in ~/config/validators.json

If there's no custom messages defined for the rule, the default message will be displayed.
